### PR TITLE
docs: fix simple typo, idnetification -> identification

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -91,7 +91,7 @@ def linkify(txt,
         host_part = parts[0]
 
         if host_part.startswith('www.'):
-            host_part = '.'.join(host_part.split('.')[1:]) # add extra idnetification for external link
+            host_part = '.'.join(host_part.split('.')[1:]) # add extra identification for external link
         if not local_domain or not host_part.endswith(local_domain):
             params  += ' class="external" '
             tb = True


### PR DESCRIPTION
There is a small typo in src/utils/text.py.

Should read `identification` rather than `idnetification`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md